### PR TITLE
Render underline and strikethrough properly on macOS

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -425,9 +425,9 @@ impl Font {
 
         // Strikeout and underline metrics
         // CoreText doesn't provide strikeout so we provide our own
-        let underline_position = self.ct_font.underline_position() as f32;
+        let underline_position = self.ct_font.underline_position() as f32 - descent as f32;
         let underline_thickness = self.ct_font.underline_thickness() as f32;
-        let strikeout_position = line_height as f32 / 2. + descent as f32;
+        let strikeout_position = line_height as f32 / 2. - descent as f32;
         let strikeout_thickness = underline_thickness;
 
         Metrics {

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -425,9 +425,13 @@ impl Font {
 
         // Strikeout and underline metrics
         // CoreText doesn't provide strikeout so we provide our own
-        let underline_position = self.ct_font.underline_position() as f32 - descent as f32;
-        let underline_thickness = self.ct_font.underline_thickness() as f32;
-        let strikeout_position = line_height as f32 / 2. - descent as f32;
+        let underline_position =
+            (self.ct_font.underline_position() - descent)
+            .floor() as f32;
+        let underline_thickness = self.ct_font.underline_thickness()
+            .round()
+            .max(1.) as f32;
+        let strikeout_position = (line_height as f32 / 2. - descent as f32).round();
         let strikeout_thickness = underline_thickness;
 
         Metrics {

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -427,7 +427,7 @@ impl Font {
         // CoreText doesn't provide strikeout so we provide our own
         let underline_position =
             (self.ct_font.underline_position() - descent)
-            .floor() as f32;
+            .round() as f32;
         let underline_thickness = self.ct_font.underline_thickness()
             .round()
             .max(1.) as f32;


### PR DESCRIPTION
Modify the positioning of the strikethrough and underline to render properly on macOS. 

Note that I currently don't know how to write a hello world in rust, just pattern matching.